### PR TITLE
Ability to override camelized_hash_keys with a constant

### DIFF
--- a/lib/infuser/contact.rb
+++ b/lib/infuser/contact.rb
@@ -14,6 +14,10 @@ module Infuser
     has_collection :faxes
     has_collection :addresses
 
+    INFUSIONSOFT_MAPPING = {
+      'CompanyId' => 'CompanyID',
+      'OwnerId' => 'OwnerID'
+    }
 
     private
 

--- a/lib/infuser/contact.rb
+++ b/lib/infuser/contact.rb
@@ -5,7 +5,7 @@ module Infuser
       :company_id, :job_title, :assistant_name, :assistant_phone,
       :contact_notes, :contact_type,
       :referral_code, :spouse_name, :username, :website,
-      :date_created, :last_updated
+      :date_created, :last_updated, :created_by
 
     belongs_to :company
 

--- a/lib/infuser/helpers/hashie.rb
+++ b/lib/infuser/helpers/hashie.rb
@@ -2,9 +2,23 @@ module Infuser
   module Helpers
     module Hashie
 
-      def camelize_hash hash
+      def camelize_hash(hash, klass_name = nil)
         hash.each_with_object({}) do |(key, value), h|
-          h[key.to_s.split('_').map { |w| safe_classify(w) }.join] = value
+          camelized_key = get_camelized_key(key, klass_name)
+          h[camelized_key] = value
+        end
+      end
+
+      def get_camelized_key(key, klass_name)
+        camelized_key = key.to_s.split('_').map{ |w| safe_classify(w)}.join
+        klass = get_klass_name(klass_name)
+        remapped_key = klass::INFUSIONSOFT_MAPPING[camelized_key] if klass
+        remapped_key || camelized_key
+      end
+
+      def get_klass_name(klass_name)
+        if klass_name
+          Infuser.const_get(klass_name) rescue nil
         end
       end
 

--- a/lib/infuser/helpers/hashie.rb
+++ b/lib/infuser/helpers/hashie.rb
@@ -2,24 +2,17 @@ module Infuser
   module Helpers
     module Hashie
 
-      def camelize_hash(hash, klass_name = nil)
+      def camelize_hash(hash)
         hash.each_with_object({}) do |(key, value), h|
-          camelized_key = get_camelized_key(key, klass_name)
+          camelized_key = get_camelized_key(key)
           h[camelized_key] = value
         end
       end
 
-      def get_camelized_key(key, klass_name)
+      def get_camelized_key(key)
         camelized_key = key.to_s.split('_').map{ |w| safe_classify(w)}.join
-        klass = get_klass_name(klass_name)
-        remapped_key = klass::INFUSIONSOFT_MAPPING[camelized_key] if klass
+        remapped_key = model_klass::INFUSIONSOFT_MAPPING[camelized_key] if model_klass
         remapped_key || camelized_key
-      end
-
-      def get_klass_name(klass_name)
-        if klass_name
-          Infuser.const_get(klass_name) rescue nil
-        end
       end
 
       def safe_classify w

--- a/lib/infuser/models/base.rb
+++ b/lib/infuser/models/base.rb
@@ -114,7 +114,7 @@ module Infuser
         collections.each do |name, proxy|
           data.merge!(proxy.data)
         end
-        camelize_hash(data, klass_name).select { |k, v| !v.nil? }
+        camelize_hash(data).select { |k, v| !v.nil? }
       end
 
       def new_record?
@@ -156,6 +156,10 @@ module Infuser
 
       def klass_name
         self.class.klass_name
+      end
+
+      def model_klass
+        Infuser.const_get(klass_name)
       end
 
       def service_name

--- a/lib/infuser/models/base.rb
+++ b/lib/infuser/models/base.rb
@@ -3,6 +3,8 @@ module Infuser
     class Base
       include Infuser::Helpers::Hashie
 
+      INFUSIONSOFT_MAPPING = {}
+
       class << self
 
         def schema
@@ -112,7 +114,7 @@ module Infuser
         collections.each do |name, proxy|
           data.merge!(proxy.data)
         end
-        camelize_hash(data).select { |k, v| !v.nil? }
+        camelize_hash(data, klass_name).select { |k, v| !v.nil? }
       end
 
       def new_record?

--- a/lib/infuser/models/base.rb
+++ b/lib/infuser/models/base.rb
@@ -159,7 +159,7 @@ module Infuser
       end
 
       def model_klass
-        Infuser.const_get(klass_name)
+        self.class
       end
 
       def service_name

--- a/lib/infuser/tables/base.rb
+++ b/lib/infuser/tables/base.rb
@@ -33,7 +33,7 @@ module Infuser
         records = []
 
         begin
-          response = client.get("DataService.query", klass_name, PAGINATION, page, camelize_hash(hash, klass_name), (model_klass.fieldset.dup << 'Id'))
+          response = client.get("DataService.query", klass_name, PAGINATION, page, camelize_hash(hash), (model_klass.fieldset.dup << 'Id'))
           page += 1
           count = response.count
 

--- a/lib/infuser/tables/base.rb
+++ b/lib/infuser/tables/base.rb
@@ -33,7 +33,7 @@ module Infuser
         records = []
 
         begin
-          response = client.get("DataService.query", klass_name, PAGINATION, page, camelize_hash(hash), (model_klass.fieldset.dup << 'Id'))
+          response = client.get("DataService.query", klass_name, PAGINATION, page, camelize_hash(hash, klass_name), (model_klass.fieldset.dup << 'Id'))
           page += 1
           count = response.count
 


### PR DESCRIPTION
@davidlesches 
I ran into an issue while creating a Contact by passing the company_id. It always sets my companyId to 0.

The camelized hash converts it to `CompanyId` but the API requires it to be `CompanyID`

![image](https://cloud.githubusercontent.com/assets/1395635/6998022/0b0b4ff0-db88-11e4-8ff5-16dc9487fb43.png)

To solve this problem, assuming camelized_hash is always used only for a model from tables or model base class
- I created a constant called INFUSIONSOFT_MAPPING
- I am mapping the the abnormal camelized keys to the proper keys.
- The camelized hash uses the value from INFUSIONSOFT_MAPPING if one is defined or uses the camelized_key.

Though I am not completely familiar with all the requirements of the gem or infusionsoft api, this solved my current problem. If you think this can be added to the gem, feel free to merge or close the PR. 

Thanks.
